### PR TITLE
 fix: add missing #include <stdlib.h> to resolve C.free undefined error in cgo

### DIFF
--- a/mpg123/mpg123.go
+++ b/mpg123/mpg123.go
@@ -3,6 +3,7 @@
 package mpg123
 
 /*
+#include <stdlib.h>
 #include <mpg123.h>
 #cgo LDFLAGS: -lmpg123
 


### PR DESCRIPTION
This PR fixes a build error encountered during compilation related to the missing standard library include for `stdlib.h`.

The error message:  `could not determine kind of name for C.free`  occurs because `C.free` is used without including `<stdlib.h>`.

### Changes included:

- Added `#include <stdlib.h>` to the cgo source file to properly define `C.free`